### PR TITLE
For upstream

### DIFF
--- a/litesata/core/link.py
+++ b/litesata/core/link.py
@@ -777,7 +777,7 @@ class LiteSATALink(Module):
         self.submodules.rx_align = LiteSATAALIGNRemover(phy_description(32))
         self.submodules.rx = BufferizeEndpoints("sink")(LiteSATALinkRX())
         self.submodules.rx_buffer = Buffer(link_description(32), buffer_depth,
-                                                 almost_full=3*buffer_depth//4)
+                                                 almost_full=3*buffer_depth//4-1)
         self.comb += self.rx.hold.eq(self.rx_buffer.almost_full)
         self.submodules.rx_pipeline = Pipeline(phy,
                                                self.rx_cont,

--- a/litesata/phy/k7/trx.py
+++ b/litesata/phy/k7/trx.py
@@ -167,16 +167,17 @@ class K7LiteSATAPHYTRX(Module):
             _RisingEdge(self.tx_comwake_stb, self.txcomwake),
         ]
 
-        self.comb += [
-            self.txcharisk.eq(self.sink.charisk),
-            self.txdata.eq(self.sink.data),
-            self.sink.ack.eq(1),
-
+        self.sync.sata_rx += [
             self.source.stb.eq(1),
             self.source.charisk.eq(self.rxcharisk),
             self.source.data.eq(self.rxdata)
         ]
 
+        self.sync.sata_tx += [
+            self.txcharisk.eq(self.sink.charisk),
+            self.txdata.eq(self.sink.data),
+            self.sink.ack.eq(1),
+        ]
     # Internals and clock domain crossing
         # sys_clk --> sata_tx clk
         txuserrdy = Signal()


### PR DESCRIPTION
Some notes
1. I'm not sure if the clock tx/rx data improves anything, but it feels better to have registers connected to the GTX instead of lots of async logic
2. The change in the almost_full check is supposed to make the tools only check if the two MSB are set instead of comparing the whole level vector. It looks like at least Vivado gets it right, but I think an even better fix would be if we could explicitly do this check (perhaps subclass Buffer and do it there?)
3. We have seen with Chipscope that tx_startup_fsm has jumped directly from RELEASE_MMCM to WAIT_ALIGN, probably because mmcm_locked wasn't properly synced. We haven't confirmed that the change to cplllock does anything, but it's a bit scary that it goes unsynchronized into a FSM.
