### PR TITLE
Wait for PLL unlock in init RX FSM when doing a full reset

### DIFF
--- a/litesata/phy/k7/crg.py
+++ b/litesata/phy/k7/crg.py
@@ -189,7 +189,9 @@ class K7LiteSATAPHYCRG(Module):
         # Reset GTX
         rx_startup_fsm.act("RESET_GTX",
             gtx.gtrxreset.eq(1),
-            NextState("WAIT_CPLL")
+            If(~gtx.gttxreset | ~self.cplllock,
+               NextState("WAIT_CPLL")
+            )
         )
         # Wait for CPLL lock
         rx_startup_fsm.act("WAIT_CPLL",


### PR DESCRIPTION
The init TX state machine already has a fix where it waits for
cplllock to deassert before checking for it to be asserted. This
fix is also needed for the init RX FSM, but only when we're doing
a full reset, since the cpll isn't reset during a RX only reset