### PR TITLE
frontend/dma: support multi-sector transfer

### DIFF
--- a/litesata/frontend/dma.py
+++ b/litesata/frontend/dma.py
@@ -96,12 +96,10 @@ class LiteSATASector2MemDMA(Module, AutoCSR):
             ),
 
             # Monitor errors
-            If(port.source.valid & port.source.ready,
-                If(port.source.failed,
-                    self.irq.eq(1),
-                    NextValue(self.error.status, 1),
-                    NextState("IDLE"),
-                )
+            If(port.source.valid & port.source.ready & port.source.failed,
+                self.irq.eq(1),
+                NextValue(self.error.status, 1),
+                NextState("IDLE"),
             )
         )
 
@@ -188,12 +186,10 @@ class LiteSATAMem2SectorDMA(Module, AutoCSR):
 
             # Monitor errors
             port.source.ready.eq(1),
-            If(port.source.valid & port.source.ready,
-                If(port.source.failed,
-                    self.irq.eq(1),
-                    NextValue(self.error.status, 1),
-                    NextState("IDLE"),
-                )
+            If(port.source.valid & port.source.ready & port.source.failed,
+                self.irq.eq(1),
+                NextValue(self.error.status, 1),
+                NextState("IDLE"),
             )
         )
         fsm.act("WAIT-ACK",


### PR DESCRIPTION
<del>CAUTION: DO NOT APPLY (yet)!]</del>

Allow up to 8 contiguous sectors to be transfered in a single DMA operation.

The max. 8 limit is based on my observation of the linux kernel's behavior, but seems rather arbitrary.

CAUTION: I also kinda sorta hacked the LiteSATA DMA frontend to increase the sector-buffer FIFO(s) by a factor of 8 (to fit up to 8 sectors). It might make more sense to decouple the FIFO size from the max. transfer size and have it work in a true "streaming" fashion, but for that I'd have to study LiteX streams, the SATA protocol, etc. in a LOT more detail :)

At the moment, I just want to start talking about this rather than push an actual change into upstream LiteSATA.

Statistics (***EDIT***: on nexys_video, with `sata-gen 1`, quad-core fpu-enabled rocket at 50MHz):
- with busy-waiting/polling for DMA transfer completion, one-sector-at-once, we have:
  - 3600 kB/s reads, and 1600 kB/s writes.
- with irq-driven one-sector-at-once transfers, we have:
  - 1000 kB/s reads, and  700 kB/s writes.
- with irq-driven up-to-8-sectors-at-once, we get:
  - 2800 kB/s reads, and 1500 kB/s writes.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>