### PR TITLE
Fix flow control during read operation

### DIFF
--- a/litesata/common.py
+++ b/litesata/common.py
@@ -40,7 +40,6 @@ primitives = {
     "R_ERR":   0x5656b57c,
     "R_IP":    0x5555b57c,
     "X_RDY":   0x5757b57c,
-    "CONT":    0x9999aa7c,
     "WTRM":    0x5858b57c,
     "SOF":     0x3737b57c,
     "EOF":     0xd5d5b57c,

--- a/litesata/core/link.py
+++ b/litesata/core/link.py
@@ -703,7 +703,7 @@ class LiteSATALinkRX(Module):
         fsm.act("COPY",
             pipeline.sink.valid.eq(data_valid),
             insert.eq(primitives["R_IP"]),
-            If(primitive_valid,
+            If(primitive_valid & (primitive != primitives["HOLDA"]),
                 If(primitive == primitives["HOLD"],
                     insert.eq(primitives["HOLDA"])
                 ).Elif(primitive == primitives["EOF"],
@@ -769,7 +769,7 @@ class LiteSATALink(Module):
         self.submodules.rx_align = LiteSATAALIGNRemover(phy_description(32))
         self.submodules.rx_cont = LiteSATACONTRemover(phy_description(32))
         self.submodules.rx = BufferizeEndpoints({"sink": DIR_SINK})(LiteSATALinkRX())
-        self.submodules.rx_buffer = stream.SyncFIFO(link_description(32), 128)
+        self.submodules.rx_buffer = stream.SyncFIFO(link_description(32), 256)
         self.submodules.rx_pipeline = Pipeline(phy, self.rx_align, self.rx_cont, self.rx, self.rx_buffer)
 
         # RX --> TX --------------------------------------------------------------------------------
@@ -778,4 +778,4 @@ class LiteSATALink(Module):
         self.sink, self.source = self.tx_pipeline.sink, self.rx_pipeline.source
 
         # Hold -------------------------------------------------------------------------------------
-        self.comb += self.rx.hold.eq(self.rx_buffer.level > 64)
+        self.comb += self.rx.hold.eq(self.rx_buffer.level > 128)


### PR DESCRIPTION
I am validating read/write operations using LiteSATAStriping with multiple SSDs (Samsung 860 EVO).

I noticed that during Read operations, when source.ready=0 in LiteSATACore, the rx_buffer of LiteSATALink becomes full, causing the flow control to malfunction.

To resolve this issue, I made a modification to continuously send HOLD primitives to the device even when LiteSATALinkRX's FSM is in the COPY state, even if HOLDA primitives are being received from the device.

Additionally, since the stability was not achieved solely by this change, I increased the depth of the receive buffer from 128 to 256. Further investigation may be necessary regarding this modification.

Furthermore, I fixed the duplicate definition of CONT in litesata/common.py.

At least, I have confirmed that these fixes resolved the issue and I am able to perform Read or Write operations using LiteSATAStriping.