### PR TITLE
uspsataphy.py, ussataphy.py: Fix PROGDIV to depend on data width

### DIFF
--- a/litesata/phy/uspsataphy.py
+++ b/litesata/phy/uspsataphy.py
@@ -159,8 +159,8 @@ class USPLiteSATAPHY(Module):
             "gen2": 20.0,
             "gen3": 10.0,
         }
-        tx_progdiv_cfg = progdiv[gen]
-        rx_progdiv_cfg = progdiv[gen]
+        tx_progdiv_cfg = {16: progdiv[gen], 32: 2. * progdiv[gen]}[data_width]
+        rx_progdiv_cfg = {16: progdiv[gen], 32: 2. * progdiv[gen]}[data_width]
 
         # TX Init ----------------------------------------------------------------------------------
         self.submodules.tx_init = tx_init = GTYTXInit(clk_freq, buffer_enable=tx_buffer_enable)

--- a/litesata/phy/ussataphy.py
+++ b/litesata/phy/ussataphy.py
@@ -159,8 +159,8 @@ class USLiteSATAPHY(Module):
             "gen2": 20.0,
             "gen3": 10.0,
         }
-        tx_progdiv_cfg = progdiv[gen]
-        rx_progdiv_cfg = progdiv[gen]
+        tx_progdiv_cfg = {16: progdiv[gen], 32: 2. * progdiv[gen]}[data_width]
+        rx_progdiv_cfg = {16: progdiv[gen], 32: 2. * progdiv[gen]}[data_width]
 
         # TX Init ----------------------------------------------------------------------------------
         self.submodules.tx_init = tx_init = GTHTXInit(clk_freq, buffer_enable=tx_buffer_enable)


### PR DESCRIPTION
I found that when setting the data_width to 32 in USLiteSATAPHY or USPLiteSATAPHY, LiteSATA does not operate.

This is because when the PHY buffer is disabled, the frequency of TXOUTCLK/RXOUTCLK does not change depending on the data width.

If the PHY data width is changed from 16 to 32, the frequency of TX/RXOUTCLK should be halved.

With this modification, I have adjusted the values of tx_progdiv_cfg/rx_progdiv_cfg to ensure the appropriate frequency of TXOUTCLK/RXOUTCLK based on the PHY data width.