### PR TITLE
phy/xilinx: Name UltraScale PHYs after transceivers

### DIFF
--- a/litesata/phy/__init__.py
+++ b/litesata/phy/__init__.py
@@ -19,16 +19,15 @@ class LiteSATAPHY(LiteXModule):
 
     Manages the low level interface between the SATA core and the device.
 
-    This modules use FPGA transceivers (high speed serializers/deserializer) to
-    communicates with the SATA devices. Since transceivers are primitives inside
-    the FPGA, device passed as parameter is used to select the right PHY. PHY is
-    composed of 3 main modules:
+    This module uses FPGA transceivers (high speed serializers/deserializers) to
+    communicate with SATA devices. Since transceivers are primitives inside the
+    FPGA, the device and transceiver type are used to select the right PHY. The
+    PHY is composed of three main modules:
     - Transceiver and clocking (vendor specific)
     - Control (vendor agnostic)
     - Datapath (vendor agnostic)
 
-    For now, the Kintex7/Zynq(with PL based on K7) PHY is the only one available,
-    but the achitecture is modular enough to accept others PHYs.
+    The architecture is modular enough to support additional PHYs.
     """
     def __init__(self, device, pads, gen, clk_freq, refclk=None, data_width=16,
                  qpll=None, gt_type="GTY", use_gtgrefclk=True, with_csr=True):
@@ -55,24 +54,24 @@ class LiteSATAPHY(LiteXModule):
             self.phy = A7LiteSATAPHY(pads, gen, clk_freq, data_width, tx_buffer_enable=True, qpll=qpll)
             self.crg = A7LiteSATAPHYCRG(refclk, pads, self.phy, gen,  tx_buffer_enable=True)
 
-        # Kintex/Virtex Ultrascale.
+        # Kintex/Virtex UltraScale GTH (GTHE3).
         elif re.match("^xc[kv]u[0-9]+-", device):
-            from litesata.phy.ussataphy import USLiteSATAPHYCRG, USLiteSATAPHY
-            self.phy = USLiteSATAPHY(pads, gen, clk_freq, data_width)
-            self.crg = USLiteSATAPHYCRG(refclk, pads, self.phy, gen)
+            from litesata.phy.gth3sataphy import GTH3LiteSATAPHYCRG, GTH3LiteSATAPHY
+            self.phy = GTH3LiteSATAPHY(pads, gen, clk_freq, data_width)
+            self.crg = GTH3LiteSATAPHYCRG(refclk, pads, self.phy, gen)
 
         # Kintex/Virtex/Zynq Ultrascale+.
         elif re.match("^xc([kv]u[0-9]+p-|zu[0-9])", device):
             if gt_type == "GTY":
-                # GTY transceiver for Virtex/Kintex Ultrascale+
-                from litesata.phy.uspsataphy import USPLiteSATAPHYCRG, USPLiteSATAPHY
-                self.phy = USPLiteSATAPHY(pads, gen, clk_freq, data_width, use_gtgrefclk=use_gtgrefclk)
-                self.crg = USPLiteSATAPHYCRG(refclk, pads, self.phy, gen)
+                # GTY transceiver for Virtex/Kintex UltraScale+ (GTYE4).
+                from litesata.phy.gty4sataphy import GTY4LiteSATAPHYCRG, GTY4LiteSATAPHY
+                self.phy = GTY4LiteSATAPHY(pads, gen, clk_freq, data_width, use_gtgrefclk=use_gtgrefclk)
+                self.crg = GTY4LiteSATAPHYCRG(refclk, pads, self.phy, gen)
             elif gt_type == "GTH":
-                # GTH transceiver for Kintex/Zynq Ultrascale+
-                from litesata.phy.gthe4sataphy import GTHE4LiteSATAPHYCRG, GTHE4LiteSATAPHY
-                self.phy = GTHE4LiteSATAPHY(pads, gen, clk_freq, data_width, use_gtgrefclk=use_gtgrefclk)
-                self.crg = GTHE4LiteSATAPHYCRG(refclk, pads, self.phy, gen)
+                # GTH transceiver for Kintex/Zynq UltraScale+ (GTHE4).
+                from litesata.phy.gth4sataphy import GTH4LiteSATAPHYCRG, GTH4LiteSATAPHY
+                self.phy = GTH4LiteSATAPHY(pads, gen, clk_freq, data_width, use_gtgrefclk=use_gtgrefclk)
+                self.crg = GTH4LiteSATAPHYCRG(refclk, pads, self.phy, gen)
             else:
                 raise NotImplementedError(f"Unsupported GT type. : {gt_type}")
 

--- a/litesata/phy/gth3sataphy.py
+++ b/litesata/phy/gth3sataphy.py
@@ -15,7 +15,7 @@ from liteiclink.serdes.common import *
 from liteiclink.serdes.gth_ultrascale_init import GTHTXInit, GTHRXInit
 
 
-class USLiteSATAPHYCRG(Module):
+class GTH3LiteSATAPHYCRG(Module):
     def __init__(self, refclk, pads, gth, gen):
         self.tx_reset = Signal()
         self.rx_reset = Signal()
@@ -64,7 +64,7 @@ class USLiteSATAPHYCRG(Module):
 
 # --------------------------------------------------------------------------------------------------
 
-class USLiteSATAPHY(Module):
+class GTH3LiteSATAPHY(Module):
     def __init__(self, pads, gen, clk_freq, data_width=16, tx_buffer_enable=False, rx_buffer_enable=False):
         assert data_width in [16, 32]
         # Common signals

--- a/litesata/phy/gth4sataphy.py
+++ b/litesata/phy/gth4sataphy.py
@@ -17,7 +17,7 @@ from litesata.phy.ctrl import *
 from litesata.phy.datapath import *
 
 
-class GTHE4LiteSATAPHYCRG(Module):
+class GTH4LiteSATAPHYCRG(Module):
     def __init__(self, refclk, pads, gth, gen):
         self.tx_reset = Signal()
         self.rx_reset = Signal()
@@ -66,7 +66,7 @@ class GTHE4LiteSATAPHYCRG(Module):
 
 # --------------------------------------------------------------------------------------------------
 
-class GTHE4LiteSATAPHY(Module):
+class GTH4LiteSATAPHY(Module):
     def __init__(self, pads, gen, clk_freq, data_width=16,
                  tx_buffer_enable=False, rx_buffer_enable=False, use_gtgrefclk=True):
         assert data_width in [16, 32]

--- a/litesata/phy/gthe4sataphy.py
+++ b/litesata/phy/gthe4sataphy.py
@@ -1,0 +1,10 @@
+#
+# This file is part of LiteSATA.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Legacy API ---------------------------------------------------------------------------------------
+
+from litesata.phy.gth4sataphy import GTH4LiteSATAPHYCRG as GTHE4LiteSATAPHYCRG
+from litesata.phy.gth4sataphy import GTH4LiteSATAPHY    as GTHE4LiteSATAPHY

--- a/litesata/phy/gty4sataphy.py
+++ b/litesata/phy/gty4sataphy.py
@@ -15,7 +15,7 @@ from liteiclink.serdes.common import *
 from liteiclink.serdes.gty_ultrascale_init import GTYTXInit, GTYRXInit
 
 
-class USPLiteSATAPHYCRG(Module):
+class GTY4LiteSATAPHYCRG(Module):
     def __init__(self, refclk, pads, gty, gen):
         self.tx_reset = Signal()
         self.rx_reset = Signal()
@@ -64,7 +64,7 @@ class USPLiteSATAPHYCRG(Module):
 
 # --------------------------------------------------------------------------------------------------
 
-class USPLiteSATAPHY(Module):
+class GTY4LiteSATAPHY(Module):
     def __init__(self, pads, gen, clk_freq, data_width=16,
                  tx_buffer_enable=False, rx_buffer_enable=False, use_gtgrefclk=True):
         assert data_width in [16, 32]

--- a/litesata/phy/uspsataphy.py
+++ b/litesata/phy/uspsataphy.py
@@ -1,0 +1,10 @@
+#
+# This file is part of LiteSATA.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Legacy API ---------------------------------------------------------------------------------------
+
+from litesata.phy.gty4sataphy import GTY4LiteSATAPHYCRG as USPLiteSATAPHYCRG
+from litesata.phy.gty4sataphy import GTY4LiteSATAPHY    as USPLiteSATAPHY

--- a/litesata/phy/ussataphy.py
+++ b/litesata/phy/ussataphy.py
@@ -1,0 +1,10 @@
+#
+# This file is part of LiteSATA.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Legacy API ---------------------------------------------------------------------------------------
+
+from litesata.phy.gth3sataphy import GTH3LiteSATAPHYCRG as USLiteSATAPHYCRG
+from litesata.phy.gth3sataphy import GTH3LiteSATAPHY    as USLiteSATAPHY

--- a/test/test_phy.py
+++ b/test/test_phy.py
@@ -1,0 +1,78 @@
+#
+# This file is part of LiteSATA.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import Instance, Signal
+
+from litesata.phy import LiteSATAPHY
+from litesata.phy.gth3sataphy import GTH3LiteSATAPHYCRG, GTH3LiteSATAPHY
+from litesata.phy.gth4sataphy import GTH4LiteSATAPHYCRG, GTH4LiteSATAPHY
+from litesata.phy.gty4sataphy import GTY4LiteSATAPHYCRG, GTY4LiteSATAPHY
+from litesata.phy.gthe4sataphy import GTHE4LiteSATAPHYCRG, GTHE4LiteSATAPHY
+from litesata.phy.uspsataphy import USPLiteSATAPHYCRG, USPLiteSATAPHY
+from litesata.phy.ussataphy import USLiteSATAPHYCRG, USLiteSATAPHY
+
+
+class SATAPads:
+    def __init__(self):
+        self.rx_p = Signal()
+        self.rx_n = Signal()
+        self.tx_p = Signal()
+        self.tx_n = Signal()
+
+
+class TestPHY(unittest.TestCase):
+    def assert_phy(self, device, gt_type, phy_cls, primitive):
+        dut = LiteSATAPHY(
+            device   = device,
+            pads     = SATAPads(),
+            gen      = "gen3",
+            clk_freq = 100e6,
+            refclk   = Signal(),
+            gt_type  = gt_type,
+            with_csr = False,
+        )
+        instances = [special.of for special in dut.phy.get_fragment().specials
+            if isinstance(special, Instance)]
+        self.assertIsInstance(dut.phy, phy_cls)
+        self.assertIn(primitive, instances)
+
+    def test_ultrascale_gth3(self):
+        self.assert_phy(
+            device    = "xcku040-ffva1156-2-e",
+            gt_type   = "GTH",
+            phy_cls   = GTH3LiteSATAPHY,
+            primitive = "GTHE3_CHANNEL",
+        )
+
+    def test_ultrascale_plus_gth4(self):
+        self.assert_phy(
+            device    = "xcku15p-ffva1156-2-e",
+            gt_type   = "GTH",
+            phy_cls   = GTH4LiteSATAPHY,
+            primitive = "GTHE4_CHANNEL",
+        )
+
+    def test_ultrascale_plus_gty4(self):
+        self.assert_phy(
+            device    = "xcvu9p-flga2104-2L-e",
+            gt_type   = "GTY",
+            phy_cls   = GTY4LiteSATAPHY,
+            primitive = "GTYE4_CHANNEL",
+        )
+
+    def test_legacy_aliases(self):
+        self.assertIs(USLiteSATAPHYCRG, GTH3LiteSATAPHYCRG)
+        self.assertIs(USLiteSATAPHY,    GTH3LiteSATAPHY)
+        self.assertIs(GTHE4LiteSATAPHYCRG, GTH4LiteSATAPHYCRG)
+        self.assertIs(GTHE4LiteSATAPHY,    GTH4LiteSATAPHY)
+        self.assertIs(USPLiteSATAPHYCRG, GTY4LiteSATAPHYCRG)
+        self.assertIs(USPLiteSATAPHY,    GTY4LiteSATAPHY)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- rename the UltraScale PHY implementations after their actual transceiver generation:
  - `USLiteSATAPHY` / `ussataphy.py` to `GTH3LiteSATAPHY` / `gth3sataphy.py`
  - `GTHE4LiteSATAPHY` / `gthe4sataphy.py` to `GTH4LiteSATAPHY` / `gth4sataphy.py`
  - `USPLiteSATAPHY` / `uspsataphy.py` to `GTY4LiteSATAPHY` / `gty4sataphy.py`
- update `LiteSATAPHY` to use the canonical modules and clarify the selected Xilinx primitives
- keep the old module paths and class names as compatibility aliases
- add regression coverage for factory selection, primitive mapping, and legacy aliases

The GTH3/GTH4 naming follows LiteICLink's transceiver-generation convention. Using GTY4 rather than a family-level USP name also leaves an unambiguous place for a future GTY3 implementation.

No transceiver parameters, clocking, datapath behavior, or device-selection rules are changed.

## Validation

- complete LiteSATA test suite: `12 passed`
- targeted PHY naming tests: `4 passed`
- verified factory mappings:
  - GTH3 to `GTHE3_CHANNEL`
  - GTH4 to `GTHE4_CHANNEL`
  - GTY4 to `GTYE4_CHANNEL`

Closes #32
