### PR TITLE
README: Clarify supported Xilinx SATA PHYs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
                                   / /__/ / __/ -_)\ \/ __ |/ / / __ |
                                  /____/_/\__/\__/___/_/ |_/_/ /_/ |_|
 
-                                  Copyright 2014-2024 / EnjoyDigital
+                                  Copyright 2014-2026 / EnjoyDigital
                                      Copyright 2014-2015 / HKU
 
                               A small footprint and configurable SATA core
@@ -32,14 +32,16 @@ design flow by generating the Verilog RTL that you will use as a standard core.
 [> Features
 -----------
 PHY:
-  - Xilinx 7-Series (Kintex7, Artix7)
-  - Xilinx Ultrascale(+)
+  - Xilinx Artix-7 GTP (`GTPE2_CHANNEL`)
+  - Xilinx Kintex-7 GTX (`GTXE2_CHANNEL`)
+  - Xilinx UltraScale GTH (`GTHE3_CHANNEL`)
+  - Xilinx UltraScale+ GTH/GTY (`GTHE4_CHANNEL`/`GTYE4_CHANNEL`, selected with `gt_type`)
   - OOB, COMWAKE, COMINIT
   - ALIGN inserter/remover and bytes alignment on K28.5
   - 8B/10B encoding/decoding in transceiver
   - Automatic TX/RX P/N polarity detection and swap.
   - Error detection and reporting
-  - 32 bits interface
+  - 16/32-bit PHY datapath
   - 1.5/3.0/6.0Gbps supported speeds (respectively 37.5/75/150MHz system clock)
 
 Core:


### PR DESCRIPTION
## Summary

- replace the broad `Xilinx Ultrascale(+)` feature entry with the exact supported FPGA transceivers and channel primitives
- document that UltraScale+ GTH/GTY selection uses `gt_type`
- correct the PHY datapath support from 32-bit only to 16/32-bit
- update the README copyright year

This is a documentation follow-up to #34 and #32. The listed mappings match the primitives selected by the current PHY implementations:

- Artix-7 GTP: `GTPE2_CHANNEL`
- Kintex-7 GTX: `GTXE2_CHANNEL`
- UltraScale GTH: `GTHE3_CHANNEL`
- UltraScale+ GTH/GTY: `GTHE4_CHANNEL` / `GTYE4_CHANNEL`

## Validation

- checked each README entry against the corresponding PHY instance
- `git diff --check`

No code or hardware behavior is changed.
