### PR TITLE
core/frontend: Support multi-FIS IDENTIFY data transfers

### DIFF
--- a/litesata/core/command.py
+++ b/litesata/core/command.py
@@ -147,6 +147,9 @@ class LiteSATACommandRX(Module):
         self.sync += \
             If(from_tx.read,
                 read_ndwords.eq(from_tx.count*sectors2dwords(1) - 1)
+            ).Elif(from_tx.identify,
+                # IDENTIFY returns exactly one 512-byte data block.
+                read_ndwords.eq(sectors2dwords(1) - 1)
             )
         self.comb += read_done.eq(dwords_counter == read_ndwords)
 
@@ -224,6 +227,10 @@ class LiteSATACommandRX(Module):
                 transport.source.ready.eq(0),
                 If(test_type("DATA"),
                     NextState("PRESENT_READ_DATA")
+                ).Elif(test_type("PIO_SETUP_D2H") & is_identify,
+                    # A drive can split a PIO data-in transfer into several
+                    # DRQ blocks, each preceded by its own PIO Setup FIS.
+                    NextState("PRESENT_PIO_SETUP_D2H")
                 ).Elif(test_type("REG_D2H"),
                     update_d2h.eq(1),
                     set_d2h_error.eq(transport.source.status[reg_d2h_status["err"]]),
@@ -262,7 +269,11 @@ class LiteSATACommandRX(Module):
             If(source.valid & source.ready,
                 If(~read_done, NextValue(dwords_counter, dwords_counter + 1)),
                 If(source.last,
-                    If(is_identify,
+                    If(is_identify & ~read_done,
+                        # Partial identify data block: more DATA (and possibly
+                        # PIO Setup) FISes follow for the remaining dwords.
+                        NextState("WAIT_READ_DATA_OR_REG_D2H")
+                    ).Elif(is_identify,
                         NextState("IDLE")
                     ).Else(
                         NextState("WAIT_READ_DATA_OR_REG_D2H")

--- a/litesata/frontend/identify.py
+++ b/litesata/frontend/identify.py
@@ -24,6 +24,12 @@ class LiteSATAIdentify(Module):
 
         source, sink = user_port.sink, user_port.source
 
+        # IDENTIFY returns exactly one 512-byte data block, but a drive can
+        # deliver it as several DATA FISes, so a per-FIS last cannot be used
+        # as the end of the transfer.
+        ndwords = logical_sector_size*8//user_port.dw
+        count   = Signal(max=ndwords)
+
         self.submodules.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
             self.done.eq(1),
@@ -38,6 +44,7 @@ class LiteSATAIdentify(Module):
         fsm.act("SEND-CMD",
             fifo.reset.eq(1),
             source.valid.eq(1),
+            NextValue(count, 0),
             If(source.valid & source.ready,
                 NextState("WAIT-ACK")
             )
@@ -52,8 +59,11 @@ class LiteSATAIdentify(Module):
             sink.ready.eq(fifo.sink.ready),
             If(sink.valid,
                 fifo.sink.valid.eq(1),
-                If(sink.last,
-                    NextState("IDLE")
+                If(sink.ready,
+                    NextValue(count, count + 1),
+                    If(count == (ndwords - 1),
+                        NextState("IDLE")
+                    )
                 )
             )
         )


### PR DESCRIPTION
IDENTIFY is a PIO data-in command and a drive may legally split the 512-byte data block into several DRQ blocks, each delivered as its own PIO Setup + DATA FIS pair. Both the command layer and the identify frontend treated the first DATA FIS last as the end of the transfer, so on such drives (observed with a Samsung 850 EVO, typically while busy with garbage collection) the remaining FISes were left in flight, identify data was truncated, and the stray FISes could collide with the next command and hang the core until a full reload.

Latch the expected 128-dword count for IDENTIFY in the command layer, accept intermediate PIO Setup FISes between DATA FISes, and only return to IDLE once the full block has been presented. Count the received dwords in the identify frontend instead of stopping at a per-FIS last.

Validated on an Artix-7 Gen2 link against a Samsung 850 EVO where back-to-back identifies previously failed more than half the time and now run clean; existing simulation tests pass.