### PR TITLE
phy: add ECP5 Gen2 SATA support

### DIFF
--- a/bench/ecpix5.py
+++ b/bench/ecpix5.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteSATA.
+#
+# Copyright (c) 2020-2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import argparse
+import os
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex.gen import *
+
+from litex.build.generic_platform import Pins, Subsignal
+from litex.soc.cores.clock import ECP5PLL
+from litex.soc.integration.builder import Builder
+from litex.soc.integration.soc import SoCMini
+
+from litex_boards.platforms import lambdaconcept_ecpix5
+
+from litesata.core import LiteSATACore
+from litesata.frontend.arbitration import LiteSATACrossbar
+from litesata.frontend.bist import LiteSATABIST
+from litesata.phy import LiteSATAPHY
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_sata_io = [
+    ("sata_tx", 0,
+        Subsignal("p", Pins("AD16")),
+        Subsignal("n", Pins("AD17")),
+    ),
+    ("sata_rx", 0,
+        Subsignal("p", Pins("AF15")),
+        Subsignal("n", Pins("AF16")),
+    ),
+]
+
+class SATAPads:
+    def __init__(self, tx, rx):
+        self.tx_p = tx.p
+        self.tx_n = tx.n
+        self.rx_p = rx.p
+        self.rx_n = rx.n
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(LiteXModule):
+    def __init__(self, platform, sys_clk_freq):
+        self.cd_sys         = ClockDomain()
+        self.cd_por         = ClockDomain(reset_less=True)
+        self.cd_sata_refclk = ClockDomain(reset_less=True)
+
+        # # #
+
+        clk100 = platform.request("clk100")
+        rst_n  = platform.request("rst_n")
+        platform.add_period_constraint(clk100, 1e9/100e6)
+
+        por_count = Signal(16, reset=2**16 - 1)
+        por_done  = Signal()
+        self.comb += [
+            self.cd_por.clk.eq(ClockSignal()),
+            por_done.eq(por_count == 0),
+        ]
+        self.sync.por += If(~por_done, por_count.eq(por_count - 1))
+
+        self.pll = pll = ECP5PLL()
+        pll.register_clkin(clk100, 100e6)
+        pll.create_clkout(self.cd_sys, sys_clk_freq, with_reset=False)
+        pll.create_clkout(self.cd_sata_refclk, 150e6)
+        self.specials += AsyncResetSynchronizer(
+            self.cd_sys, ~por_done | ~pll.locked | ~rst_n)
+
+# SATATestSoC --------------------------------------------------------------------------------------
+
+class SATATestSoC(SoCMini):
+    def __init__(self, platform, sys_clk_freq=int(90e6)):
+        self.crg = _CRG(platform, sys_clk_freq)
+        SoCMini.__init__(self, platform, sys_clk_freq, ident="LiteSATA bench on ECPIX-5.")
+
+        self.add_uartbone(baudrate=1e6)
+
+        self.sata_phy = LiteSATAPHY(platform.device,
+            refclk     = self.crg.cd_sata_refclk.clk,
+            pads       = SATAPads(platform.request("sata_tx"), platform.request("sata_rx")),
+            gen        = "gen2",
+            clk_freq   = sys_clk_freq,
+            data_width = 16,
+            dual       = 1,
+            channel    = 0,
+        )
+        self.sata_core     = LiteSATACore(self.sata_phy)
+        self.sata_crossbar = LiteSATACrossbar(self.sata_core)
+        self.sata_bist     = LiteSATABIST(self.sata_crossbar, with_csr=True)
+
+        platform.add_period_constraint(self.sata_phy.crg.cd_sata_tx.clk, 1e9/150e6)
+        platform.add_period_constraint(self.sata_phy.crg.cd_sata_rx.clk, 1e9/150e6)
+        platform.add_false_path_constraints(
+            self.crg.cd_sys.clk,
+            self.sata_phy.crg.cd_sata_tx.clk,
+            self.sata_phy.crg.cd_sata_rx.clk,
+        )
+
+        counter = Signal(32)
+        self.sync += counter.eq(counter + 1)
+        self.comb += [
+            platform.request("rgb_led", 0).g.eq(~counter[26]),
+            platform.request("rgb_led", 1).g.eq(~self.sata_phy.ready),
+        ]
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteSATA bench on ECPIX-5.")
+    parser.add_argument("--build", action="store_true", help="Build bitstream.")
+    parser.add_argument("--load",  action="store_true", help="Load bitstream to SRAM.")
+    parser.add_argument("--device", default="85F", help="FPGA device (85F or 45F).")
+    parser.add_argument("--seed", default=3, type=int, help="nextpnr placement seed.")
+    args = parser.parse_args()
+
+    platform = lambdaconcept_ecpix5.Platform(device=args.device, toolchain="trellis")
+    platform.add_extension(_sata_io)
+    soc = SATATestSoC(platform)
+    builder = Builder(soc, csr_csv="csr.csv")
+    builder.build(run=args.build, seed=args.seed)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + ".bit"))
+
+if __name__ == "__main__":
+    main()

--- a/litesata/phy/__init__.py
+++ b/litesata/phy/__init__.py
@@ -30,7 +30,8 @@ class LiteSATAPHY(LiteXModule):
     The architecture is modular enough to support additional PHYs.
     """
     def __init__(self, device, pads, gen, clk_freq, refclk=None, data_width=16,
-                 qpll=None, gt_type="GTY", use_gtgrefclk=True, with_csr=True):
+                 qpll=None, gt_type="GTY", use_gtgrefclk=True, with_csr=True,
+                 dual=0, channel=0):
         self.pads   = pads
         self.gen    = gen
         self.refclk = refclk
@@ -41,6 +42,8 @@ class LiteSATAPHY(LiteXModule):
 
         # Transceiver / Clocks.
         # ---------------------
+
+        ctrl_cls = LiteSATAPHYCtrl
 
         # Kintex7.
         if re.match("^xc7k", device):
@@ -77,9 +80,14 @@ class LiteSATAPHY(LiteXModule):
 
         # ECP5.
         elif re.match("^LFE5UM5G-", device):
-            from litesata.phy.ecp5sataphy import ECP5LiteSATAPHYCRG, ECP5LiteSATAPHY
-            self.phy = ECP5LiteSATAPHY(refclk, pads, gen, clk_freq, data_width)
+            if gen != "gen2":
+                raise NotImplementedError("ECP5 SATA currently supports Gen2 only.")
+            from litesata.phy.ecp5sataphy import \
+                ECP5LiteSATAPHYCRG, ECP5LiteSATAPHY, ECP5LiteSATAPHYCtrl
+            self.phy = ECP5LiteSATAPHY(
+                refclk, pads, gen, clk_freq, data_width, dual=dual, channel=channel)
             self.crg = ECP5LiteSATAPHYCRG(self.phy)
+            ctrl_cls = ECP5LiteSATAPHYCtrl
 
         # Unknown.
         else:
@@ -87,7 +95,7 @@ class LiteSATAPHY(LiteXModule):
 
         # Control.
         # --------
-        self.ctrl = LiteSATAPHYCtrl(self.phy, self.crg, clk_freq)
+        self.ctrl = ctrl_cls(self.phy, self.crg, clk_freq)
 
         # Datapath.
         # ---------
@@ -103,6 +111,8 @@ class LiteSATAPHY(LiteXModule):
         if hasattr(self.phy, "tx_init") and hasattr(self.phy, "rx_init"):
             self.comb += self.phy.tx_init.restart.eq(~self.enable)
             self.comb += self.phy.rx_init.restart.eq(~self.enable | self.ctrl.rx_reset)
+        elif hasattr(self.phy, "serdes"):
+            self.comb += self.phy.serdes.init.rst.eq(~self.enable)
         self.comb += self.ready.eq(self.phy.ready & self.ctrl.ready)
 
         # CSRs.
@@ -136,6 +146,9 @@ class LiteSATAPHY(LiteXModule):
         if hasattr(self.phy, "tx_init") and hasattr(self.phy, "rx_init"):
             self.comb += self._status.fields.tx_ready.eq(self.phy.tx_init.done)
             self.comb += self._status.fields.rx_ready.eq(self.phy.rx_init.done)
+        elif hasattr(self.phy, "serdes"):
+            self.comb += self._status.fields.tx_ready.eq(self.phy.serdes.tx_ready)
+            self.comb += self._status.fields.rx_ready.eq(self.phy.serdes.rx_ready)
         else:
             self.comb += self._status.fields.tx_ready.eq(self.phy.ready)
             self.comb += self._status.fields.rx_ready.eq(self.phy.ready)

--- a/litesata/phy/ctrl.py
+++ b/litesata/phy/ctrl.py
@@ -46,10 +46,9 @@ class LiteSATAPHYCtrl(LiteXModule):
         self.comb += sink.ready.eq(1)
 
         # Retry / Align count/timers.
-        retry_timer = WaitTimer(self.us(10000))
-        align_timer = WaitTimer(self.us(873))
+        self.retry_timer = retry_timer = WaitTimer(self.us(10000))
+        self.align_timer = align_timer = WaitTimer(self.us(873))
         align_count = Signal(4)
-        self.submodules += align_timer, retry_timer
 
         # Drive Transceiver/CRG idle/reset from internal logic.
         self.sync += trx.tx_idle.eq(self.tx_idle)

--- a/litesata/phy/ecp5sataphy.py
+++ b/litesata/phy/ecp5sataphy.py
@@ -1,0 +1,432 @@
+#
+# This file is part of LiteSATA.
+#
+# Copyright (c) 2020-2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from math import ceil
+
+from migen.genlib.cdc       import MultiReg
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex.gen import *
+from litex.gen.genlib.misc import WaitTimer
+
+from liteiclink.serdes.serdes_ecp5 import SerDesECP5PLL, SerDesECP5
+
+from litesata.common import *
+from litesata.common import _PulseSynchronizer
+from litesata.phy.ctrl import LiteSATAPHYCtrl
+
+# Pads ---------------------------------------------------------------------------------------------
+
+class Pads:
+    def __init__(self, p, n):
+        self.p = p
+        self.n = n
+
+# ECP5LiteSATAPHYCRG -------------------------------------------------------------------------------
+
+class ECP5LiteSATAPHYCRG(LiteXModule):
+    def __init__(self, phy):
+        self.tx_reset = Signal()
+        self.rx_reset = Signal()
+
+        self.cd_sata_tx = ClockDomain()
+        self.cd_sata_rx = ClockDomain()
+
+        # # #
+
+        serdes = phy.serdes
+        self.comb += [
+            self.cd_sata_tx.clk.eq(serdes.cd_tx.clk),
+            self.cd_sata_rx.clk.eq(serdes.cd_rx.clk),
+        ]
+        self.specials += [
+            AsyncResetSynchronizer(self.cd_sata_tx, ~serdes.tx_ready | self.tx_reset),
+            AsyncResetSynchronizer(self.cd_sata_rx, ~serdes.rx_ready | self.rx_reset),
+        ]
+
+# ECP5 SATA OOB Generator --------------------------------------------------------------------------
+
+class ECP5SATAOOBGenerator(LiteXModule):
+    """Generate the six burst/gap pairs of a SATA OOB sequence."""
+    def __init__(self, tx_clk_freq):
+        self.cominit = Signal()
+        self.comwake = Signal()
+        self.finish  = Signal()
+        self.active  = Signal()
+        self.gap     = Signal()
+
+        # # #
+
+        # SATA OOB timing uses Gen1 unit intervals, also on Gen2 links.
+        cycles       = lambda ui: round(ui*tx_clk_freq/1.5e9)
+        burst_cycles = cycles(160)
+        wake_cycles  = cycles(160)
+        init_cycles  = cycles(480)
+        assert burst_cycles >= 4
+
+        count       = Signal(8)
+        bursts_left = Signal(3)  # Five remaining after the first burst gives six total.
+        is_wake     = Signal()
+
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(self.cominit | self.comwake,
+                NextValue(is_wake, self.comwake & ~self.cominit),
+                # Release electrical idle one TX cycle before the measured sequence.
+                NextValue(count, 0),
+                NextValue(bursts_left, 5),
+                NextState("PRE")
+            )
+        )
+        fsm.act("PRE",
+            self.active.eq(1),
+            NextValue(count, count - 1),
+            If(count == 0,
+                NextValue(count, burst_cycles - 1),
+                NextState("BURST")
+            )
+        )
+        fsm.act("BURST",
+            self.active.eq(1),
+            NextValue(count, count - 1),
+            If(count == 0,
+                NextValue(count, Mux(is_wake, wake_cycles - 1, init_cycles - 1)),
+                NextState("GAP")
+            )
+        )
+        fsm.act("GAP",
+            self.active.eq(1),
+            self.gap.eq(1),
+            NextValue(count, count - 1),
+            If(count == 0,
+                If(bursts_left == 0,
+                    NextState("FINISH")
+                ).Else(
+                    NextValue(bursts_left, bursts_left - 1),
+                    NextValue(count, burst_cycles - 1),
+                    NextState("BURST")
+                )
+            )
+        )
+        fsm.act("FINISH",
+            self.active.eq(1),
+            self.gap.eq(1),
+            self.finish.eq(1),
+            NextState("WAIT")
+        )
+        fsm.act("WAIT",
+            If(~self.cominit & ~self.comwake,
+                NextState("IDLE")
+            )
+        )
+
+# ECP5 SATA OOB Checker ----------------------------------------------------------------------------
+
+class ECP5SATAOOBChecker(LiteXModule):
+    """Classify the idle gaps of received COMINIT and COMWAKE sequences."""
+    def __init__(self, clk_freq):
+        self.rx_idle     = Signal()
+        self.cominit_det = Signal()
+        self.comwake_det = Signal()
+
+        # # #
+
+        # Classify COMWAKE/COMINIT from ECP5 RLOS gap timing.
+        wake_min = ceil( 55e-9*clk_freq)
+        wake_max = int( 175e-9*clk_freq)
+        init_min = ceil(175e-9*clk_freq)
+        init_max = int( 525e-9*clk_freq)
+        quiet    = 32
+
+        rx_idle_d = Signal()
+        gap_end   = Signal()
+        gap_count = Signal(16)
+        init_gaps = Signal(3)
+        wake_gaps = Signal(3)
+        self.sync += rx_idle_d.eq(self.rx_idle)
+        self.comb += gap_end.eq(rx_idle_d & ~self.rx_idle)
+
+        self.sync += [
+            If(self.rx_idle,
+                If(gap_count != (2**16 - 1),
+                    gap_count.eq(gap_count + 1)
+                )
+            ).Else(
+                gap_count.eq(0)
+            )
+        ]
+
+        wake_gap = Signal()
+        init_gap = Signal()
+        self.comb += [
+            wake_gap.eq((gap_count >= wake_min) & (gap_count <= wake_max)),
+            init_gap.eq((gap_count >= init_min) & (gap_count <= init_max)),
+        ]
+
+        # Four gaps identify the six-burst sequence; clear detection after a quiet interval.
+        self.sync += [
+            If(gap_end,
+                If(wake_gap,
+                    If(wake_gaps != 3, wake_gaps.eq(wake_gaps + 1)),
+                    init_gaps.eq(0),
+                ).Elif(init_gap,
+                    If(init_gaps != 3, init_gaps.eq(init_gaps + 1)),
+                    wake_gaps.eq(0),
+                ).Else(
+                    init_gaps.eq(0),
+                    wake_gaps.eq(0),
+                )
+            ),
+            If(gap_count == quiet,
+                self.cominit_det.eq(0),
+                self.comwake_det.eq(0),
+                init_gaps.eq(0),
+                wake_gaps.eq(0),
+            ),
+            If(gap_end & wake_gap & (wake_gaps == 3),
+                self.comwake_det.eq(1)
+            ),
+            If(gap_end & init_gap & (init_gaps == 3),
+                self.cominit_det.eq(1)
+            ),
+        ]
+
+# ECP5LiteSATAPHYCtrl ------------------------------------------------------------------------------
+
+class ECP5LiteSATAPHYCtrl(LiteSATAPHYCtrl):
+    """Adapt the OOB/ALIGN handoff to ECP5 RLOS behavior and early device ALIGN."""
+    def __init__(self, trx, crg, clk_freq):
+        LiteSATAPHYCtrl.__init__(self, trx, crg, clk_freq)
+
+        sink        = self.sink
+        source      = self.source
+        fsm         = self.fsm
+        align_count = Signal(2)
+
+        # Latch ALIGN received before the controller has left COMWAKE.
+        align_seen     = Signal()
+        align_polarity = Signal()
+        self.sync += If(fsm.ongoing("COMWAKE"),
+            align_seen.eq(0)
+        ).Elif(
+            sink.valid &
+            (sink.charisk == 0b0001) &
+            ((sink.data == primitives["ALIGN"]) | (sink.data == primitives["ALIGN_N"])),
+            align_seen.eq(1),
+            align_polarity.eq(sink.data == primitives["ALIGN_N"])
+        )
+
+        # Bound sticky COMWAKE and require a short ALIGN dwell.
+        nocomwake_timer    = WaitTimer(ceil(0.4e-6*clk_freq))
+        align_accept_timer = WaitTimer(ceil(20e-6*clk_freq))
+        self.submodules += nocomwake_timer, align_accept_timer
+
+        # Qualify the full dword while the receive aligner settles.
+        valid_non_align = 0
+        for name, value in primitives.items():
+            if name not in ["ALIGN", "ALIGN_N"]:
+                valid_non_align = valid_non_align | (sink.data == value)
+
+        # Override only the ECP5 handoff states; the generic controller remains unchanged.
+        fsm.actions["AWAIT-NO-COMWAKE"] = [
+            self.tx_idle.eq(1),
+            trx.rx_cdrhold.eq(1),
+            nocomwake_timer.wait.eq(1),
+            If(~trx.rx_comwake_stb | nocomwake_timer.done,
+                NextState("AWAIT-ALIGN")
+            )
+        ]
+        fsm.actions["AWAIT-ALIGN"] = [
+            # Keep the CDR tracking the device's ALIGN stream.
+            source.data.eq(0x4a4a4a4a),  # D10.2
+            source.charisk.eq(0b0000),
+            self.align_timer.wait.eq(1),
+            If(align_seen,
+                NextValue(trx.rx_polarity, align_polarity),
+                # Require three consecutive qualified primitives before entering READY.
+                NextValue(align_count, 2),
+                NextState("SEND-ALIGN")
+            )
+        ]
+        fsm.actions["SEND-ALIGN"] = [
+            self.align_timer.wait.eq(1),
+            align_accept_timer.wait.eq(1),
+            source.data.eq(primitives["ALIGN"]),
+            source.charisk.eq(0b0001),
+            If(sink.valid,
+                # Accept repeated ALIGN after a dwell; accept other primitives immediately.
+                If((sink.charisk == 0b0001) &
+                   (valid_non_align |
+                    ((sink.data == primitives["ALIGN"]) & align_accept_timer.done)),
+                    If(align_count == 0,
+                        NextState("READY")
+                    ).Else(
+                        NextValue(align_count, align_count - 1)
+                    )
+                ).Else(
+                    NextValue(align_count, 2)
+                )
+            )
+        ]
+
+# ECP5LiteSATAPHY ----------------------------------------------------------------------------------
+
+class ECP5LiteSATAPHY(LiteXModule):
+    def __init__(self, refclk, pads, gen, clk_freq, data_width=16, dual=0, channel=0,
+        refclk_freq=150e6):
+        assert gen == "gen2"
+        assert data_width == 16
+        assert isinstance(refclk, (Signal, ClockSignal))
+
+        self.data_width = data_width
+
+        # Control.
+        self.ready          = Signal()
+        self.tx_idle        = Signal()
+        self.tx_polarity    = Signal()
+        self.tx_cominit_stb = Signal()
+        self.tx_cominit_ack = Signal()
+        self.tx_comwake_stb = Signal()
+        self.tx_comwake_ack = Signal()
+        self.rx_idle        = Signal()
+        self.rx_cdrhold     = Signal()
+        self.rx_polarity    = Signal()
+        self.rx_cominit_stb = Signal()
+        self.rx_comwake_stb = Signal()
+        self.rxdisperr      = Signal(data_width//8)
+        self.rxnotintable   = Signal(data_width//8)
+
+        # Datapath.
+        self.sink   = stream.Endpoint(phy_description(data_width))
+        self.source = stream.Endpoint(phy_description(data_width))
+
+        # # #
+
+        linerate    = 3e9
+        tx_clk_freq = linerate/20
+
+        self.pll = SerDesECP5PLL(refclk, refclk_freq=refclk_freq, linerate=linerate)
+        self.serdes = serdes = SerDesECP5(self.pll,
+            tx_pads        = Pads(pads.tx_p, pads.tx_n),
+            rx_pads        = Pads(pads.rx_p, pads.rx_n),
+            dual           = dual,
+            channel        = channel,
+            data_width     = 20,
+            tx_polarity    = self.tx_polarity,
+            rx_polarity    = self.rx_polarity,
+            with_oob       = True,
+        )
+        serdes.add_stream_endpoints()
+
+        # Use LUNA's ECP5 receive settings and decouple CDR acquisition from RLOS.
+        serdes.serdes_params.update(
+            p_CHX_REQ_EN         = "0b1",
+            p_CHX_REQ_LVL_SET    = "0b01",
+            p_CHX_RXTERM_CM      = "0b10",
+            p_CHX_RX_LOS_HYST_EN = "0b0",
+            p_CHX_RX_LOS_LVL     = "0b010",
+            p_CHX_PDEN_SEL       = "0b0",
+            p_D_CDR_LOL_SET      = "0b10",
+        )
+
+        # TX readiness starts COMRESET since no receive signal exists yet.
+        self.comb += [
+            self.ready.eq(serdes.tx_ready),
+            serdes.tx_idle.eq(self.tx_idle),
+            serdes.rx_cdr_hold.eq(self.rx_cdrhold),
+            self.rx_idle.eq(serdes.rx_idle),
+        ]
+
+        # SATA datapath.
+        tx_data    = Signal(data_width)
+        tx_charisk = Signal(data_width//8)
+        self.comb += [
+            serdes.sink.data.eq(tx_data),
+            serdes.sink.ctrl.eq(tx_charisk),
+        ]
+        self.sync.sata_rx += [
+            self.source.valid.eq(1),
+            self.source.charisk.eq(serdes.source.ctrl),
+            self.source.data.eq(serdes.source.data),
+        ]
+
+        # Send SYNC while idle; persistent D0.0 makes devices drop a healthy link.
+        sync_half = Signal()
+        self.sync.sata_tx += [
+            If(self.sink.valid,
+                tx_charisk.eq(self.sink.charisk),
+                tx_data.eq(self.sink.data),
+                sync_half.eq(0),
+            ).Else(
+                sync_half.eq(~sync_half),
+                If(sync_half,
+                    tx_charisk.eq(0b00),
+                    tx_data.eq(primitives["SYNC"] >> 16),
+                ).Else(
+                    tx_charisk.eq(0b01),
+                    tx_data.eq(primitives["SYNC"]),
+                )
+            ),
+            self.sink.ready.eq(1),
+        ]
+
+        rxnotintable = Signal(data_width//8)
+        self.comb += [
+            rxnotintable.eq(Cat(*[decoder.invalid for decoder in serdes.decoders])),
+            self.rxdisperr.eq(0),
+        ]
+        self.specials += MultiReg(rxnotintable, self.rxnotintable, "sys")
+
+        # TX OOB.
+        self.com_gen = com_gen = ClockDomainsRenamer("tx")(ECP5SATAOOBGenerator(tx_clk_freq))
+        tx_cominit = Signal()
+        tx_comwake = Signal()
+        self.specials += [
+            MultiReg(self.tx_cominit_stb, tx_cominit, "tx"),
+            MultiReg(self.tx_comwake_stb, tx_comwake, "tx"),
+        ]
+        self.comb += [
+            com_gen.cominit.eq(tx_cominit),
+            com_gen.comwake.eq(tx_comwake),
+        ]
+
+        tx_comfinish = Signal()
+        self.submodules += _PulseSynchronizer(com_gen.finish, "tx", tx_comfinish, "sys")
+        self.comb += [
+            self.tx_cominit_ack.eq(self.tx_cominit_stb & tx_comfinish),
+            self.tx_comwake_ack.eq(self.tx_comwake_stb & tx_comfinish),
+        ]
+
+        # Alternating Gen2 words form the Gen1 OOB carrier; a constant word forms the gap.
+        pattern_toggle = Signal()
+        self.sync.tx += pattern_toggle.eq(~pattern_toggle)
+        self.comb += [
+            serdes.tx_raw_enable.eq(com_gen.active),
+            serdes.tx_raw_data.eq(Mux(com_gen.gap, 0,
+                Mux(pattern_toggle, 0x0f0f0, 0xf0f0f))),
+        ]
+
+        # Debounce RLOS for three sys cycles before measuring OOB gaps.
+        rx_idle_f = Signal()
+        filter_count = Signal(2)
+        self.sync += [
+            If(serdes.rx_idle == rx_idle_f,
+                filter_count.eq(0)
+            ).Else(
+                filter_count.eq(filter_count + 1),
+                If(filter_count == 2,
+                    rx_idle_f.eq(serdes.rx_idle),
+                    filter_count.eq(0),
+                )
+            )
+        ]
+
+        self.com_check = com_check = ECP5SATAOOBChecker(clk_freq)
+        self.comb += [
+            com_check.rx_idle.eq(rx_idle_f),
+            self.rx_cominit_stb.eq(com_check.cominit_det),
+            self.rx_comwake_stb.eq(com_check.comwake_det),
+        ]

--- a/test/test_phy.py
+++ b/test/test_phy.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
+import inspect
 import unittest
 
 from migen import ClockDomain, Instance, Module, Signal
@@ -12,11 +13,13 @@ from migen.sim import run_simulation
 from litex.soc.interconnect import stream
 
 from litesata.phy import LiteSATAPHY
+from litesata.phy.a7sataphy import A7LiteSATAPHY
 from litesata.phy.datapath import LiteSATAPHYDatapathRX
 from litesata.phy.gth3sataphy import GTH3LiteSATAPHYCRG, GTH3LiteSATAPHY
 from litesata.phy.gth4sataphy import GTH4LiteSATAPHYCRG, GTH4LiteSATAPHY
 from litesata.phy.gty4sataphy import GTY4LiteSATAPHYCRG, GTY4LiteSATAPHY
 from litesata.phy.gthe4sataphy import GTHE4LiteSATAPHYCRG, GTHE4LiteSATAPHY
+from litesata.phy.k7sataphy import K7LiteSATAPHY
 from litesata.phy.uspsataphy import USPLiteSATAPHYCRG, USPLiteSATAPHY
 from litesata.phy.ussataphy import USLiteSATAPHYCRG, USLiteSATAPHY
 
@@ -30,6 +33,11 @@ class SATAPads:
 
 
 class TestPHY(unittest.TestCase):
+    def test_constructor_keeps_legacy_positional_order(self):
+        parameters = list(inspect.signature(LiteSATAPHY.__init__).parameters)
+        self.assertLess(parameters.index("with_csr"), parameters.index("dual"))
+        self.assertLess(parameters.index("with_csr"), parameters.index("channel"))
+
     def assert_phy(self, device, gt_type, phy_cls, primitive):
         dut = LiteSATAPHY(
             device   = device,
@@ -67,6 +75,22 @@ class TestPHY(unittest.TestCase):
             gt_type   = "GTY",
             phy_cls   = GTY4LiteSATAPHY,
             primitive = "GTYE4_CHANNEL",
+        )
+
+    def test_7series_kintex7(self):
+        self.assert_phy(
+            device    = "xc7k325tffg900-2",
+            gt_type   = "GTY",
+            phy_cls   = K7LiteSATAPHY,
+            primitive = "GTXE2_CHANNEL",
+        )
+
+    def test_7series_artix7(self):
+        self.assert_phy(
+            device    = "xc7a200tsbg484-1",
+            gt_type   = "GTY",
+            phy_cls   = A7LiteSATAPHY,
+            primitive = "GTPE2_CHANNEL",
         )
 
     def test_legacy_aliases(self):

--- a/test/test_phy_ctrl.py
+++ b/test/test_phy_ctrl.py
@@ -1,0 +1,120 @@
+#
+# This file is part of LiteSATA.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import inspect
+import unittest
+
+from migen import Module, Signal
+from migen.sim import run_simulation
+
+from litesata.common import primitives
+from litesata.phy.ctrl import LiteSATAPHYCtrl
+from litesata.phy.ecp5sataphy import ECP5LiteSATAPHYCtrl
+
+
+class PHYInterface:
+    def __init__(self):
+        self.ready          = Signal()
+        self.tx_idle        = Signal()
+        self.rx_idle        = Signal()
+        self.rx_cdrhold     = Signal()
+        self.rx_polarity    = Signal()
+        self.tx_polarity    = Signal()
+        self.tx_cominit_stb = Signal()
+        self.tx_cominit_ack = Signal()
+        self.rx_cominit_stb = Signal()
+        self.tx_comwake_stb = Signal()
+        self.tx_comwake_ack = Signal()
+        self.rx_comwake_stb = Signal()
+
+
+class CRGInterface:
+    def __init__(self):
+        self.tx_reset = Signal()
+        self.rx_reset = Signal()
+
+
+class DUT(Module):
+    def __init__(self, with_early_align=False):
+        self.trx = PHYInterface()
+        self.crg = CRGInterface()
+        ctrl_cls = ECP5LiteSATAPHYCtrl if with_early_align else LiteSATAPHYCtrl
+        self.submodules.ctrl = ctrl_cls(self.trx, self.crg, clk_freq=1e6)
+
+
+class TestPHYCtrl(unittest.TestCase):
+    def test_constructor_keeps_legacy_positional_order(self):
+        parameters = list(inspect.signature(LiteSATAPHYCtrl.__init__).parameters)
+        self.assertEqual(parameters, [
+            "self",
+            "trx",
+            "crg",
+            "clk_freq",
+        ])
+
+    def run_early_align(self, with_early_align):
+        dut    = DUT(with_early_align=with_early_align)
+        result = {}
+
+        def wait_high(signal):
+            for _ in range(32):
+                if (yield signal):
+                    return
+                yield
+            self.fail("PHY controller handshake timed out")
+
+        def generator():
+            yield dut.trx.ready.eq(1)
+            yield dut.trx.tx_cominit_ack.eq(1)
+            yield dut.trx.tx_comwake_ack.eq(1)
+            yield dut.trx.rx_idle.eq(0)
+
+            yield from wait_high(dut.trx.tx_cominit_stb)
+            yield
+            while (yield dut.trx.tx_cominit_stb):
+                yield
+
+            yield dut.trx.rx_cominit_stb.eq(1)
+            yield
+            yield
+            yield dut.trx.rx_cominit_stb.eq(0)
+
+            yield from wait_high(dut.trx.tx_comwake_stb)
+            yield
+            while (yield dut.trx.tx_comwake_stb):
+                yield
+
+            # Present ALIGN while COMWAKE is still asserted, then remove it before AWAIT-ALIGN.
+            yield dut.trx.rx_comwake_stb.eq(1)
+            yield dut.ctrl.sink.valid.eq(1)
+            yield dut.ctrl.sink.charisk.eq(0b0001)
+            yield dut.ctrl.sink.data.eq(primitives["ALIGN"])
+            yield
+            yield
+            yield dut.ctrl.sink.valid.eq(0)
+            yield dut.trx.rx_comwake_stb.eq(0)
+            for _ in range(4):
+                yield
+
+            result["charisk"] = (yield dut.ctrl.source.charisk)
+            result["data"]    = (yield dut.ctrl.source.data)
+
+        run_simulation(dut, generator())
+        return result
+
+    def test_legacy_mode_does_not_latch_early_align(self):
+        result = self.run_early_align(with_early_align=False)
+        self.assertEqual(result["charisk"], 0)
+        self.assertEqual(result["data"], 0x4a4a4a4a)
+
+    def test_early_align_latch_is_opt_in(self):
+        result = self.run_early_align(with_early_align=True)
+        self.assertEqual(result["charisk"], 0b0001)
+        self.assertEqual(result["data"], primitives["ALIGN"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This progresses #27 with a clean Gen2 implementation for ECP5 and an ECPIX-5 validation bench.

- add an ECP5 SATA PHY based on the LiteICLink raw 10BSER datapath
- generate six-burst COMRESET/COMWAKE sequences with Gen1-rate D24.3 content and detect device OOB from RLOS gap timing
- scope the required controller behavior to ECP5: release CDR hold for ALIGN, tolerate RLOS during ALIGN, latch an early device ALIGN, bound COMWAKE deassertion, and validate complete primitives
- accept a device that continues complete ALIGN primitives after a 20 us SEND-ALIGN dwell
- add an ECPIX-5 UARTBone/core/BIST bench with explicit 90 MHz and 150 MHz timing constraints

Gen2 is intentional for this first mergeable implementation; Gen1 negotiation and Linux
integration remain follow-up work in #27.

## Dependency

Uses the ECP5 OOB support merged in enjoy-digital/liteiclink#33 for independent initialization,
raw OOB drive, direct electrical idle, and fabric receive alignment.

## Compatibility

The generic controller's constructor and FSM are unchanged. Its existing ALIGN and retry timers
are exposed as public attributes and remain normal LiteXModule submodules. All ECP5-specific
handling is contained in an `ECP5LiteSATAPHYCtrl` subclass beside the ECP5 PHY, where it overrides
the three OOB/ALIGN handoff states. Comparing the default controller Verilog with `master` shows
only the ordering of the two independent timer blocks has changed; their logic and the FSM are
unchanged.

Regression coverage instantiates Artix-7, Kintex-7, UltraScale GTH, UltraScale+ GTH, and
UltraScale+ GTY PHYs. The KC705 Gen3, Nexys Video Gen2, and KCU105 Gen3 benches also elaborate
successfully without selecting any ECP5 exception.

## Validation

- full LiteSATA test suite: 21 passed
- ECPIX-5 85F final timing: sys 105.39 MHz / RX 243.13 MHz / TX 264.34 MHz for 90/150/150 MHz constraints
- hardware Gen2 link remains READY at status `0x0f`
- complete 256-word IDENTIFY: Toshiba DT01ACA100, 1 TB, firmware MS2OA8U0
- destructive BIST at LBA 2,097,152: 32,768 sectors / 16 MiB pseudorandom write and verify, zero aborts and zero mismatches
- qualified bitstream SHA-256: `add6d2fe324754fc4a1353f2cf6cd2b2bce33a632ce28ea2582acd59f8a63e7d`
